### PR TITLE
feat: integrate supabase auth and database

### DIFF
--- a/env.json
+++ b/env.json
@@ -1,5 +1,5 @@
 {
-    "SUPABASE_URL": "https://dummy.supabase.co",
+    "SUPABASE_URL": "https://ervearumraidtlipdywm.supabase.co",
     "SUPABASE_ANON_KEY": "dummykey.updateyourkkey.here",
     "OPENAI_API_KEY": "your-openai-api-key-here",
     "GEMINI_API_KEY": "your-gemini-api-key-here",

--- a/lib/core/app_export.dart
+++ b/lib/core/app_export.dart
@@ -3,3 +3,5 @@ export '../routes/app_routes.dart';
 export '../widgets/custom_icon_widget.dart';
 export '../widgets/custom_image_widget.dart';
 export '../theme/app_theme.dart';
+export 'env.dart';
+export 'supabase_service.dart';

--- a/lib/core/env.dart
+++ b/lib/core/env.dart
@@ -1,0 +1,4 @@
+class Env {
+  static const supabaseUrl = 'https://ervearumraidtlipdywm.supabase.co';
+  static const supabaseAnonKey = 'dummykey.updateyourkkey.here';
+}

--- a/lib/core/supabase_service.dart
+++ b/lib/core/supabase_service.dart
@@ -1,0 +1,21 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'env.dart';
+
+class SupabaseService {
+  SupabaseService._();
+
+  static SupabaseClient get client => Supabase.instance.client;
+
+  static Future<void> init() async {
+    await Supabase.initialize(url: Env.supabaseUrl, anonKey: Env.supabaseAnonKey);
+  }
+
+  static Future<AuthResponse> signIn(String email, String password) {
+    return client.auth.signInWithPassword(email: email, password: password);
+  }
+
+  static Future<dynamic> fetchTable(String table) {
+    return client.from(table).select();
+  }
+}

--- a/lib/main-updated.dart
+++ b/lib/main-updated.dart
@@ -12,6 +12,7 @@ import 'package:sizer/sizer.dart';
 
 import '../core/app_export.dart';
 import '../widgets/custom_error_widget.dart';
+import '../core/supabase_service.dart';
 
 var backendURL = "https://mutuus5375back.builtwithrocket.new/log-error";
 
@@ -20,6 +21,7 @@ void main() async {
     _sendOverflowError(details);
   };
   WidgetsFlutterBinding.ensureInitialized();
+  await SupabaseService.init();
 
   // 🚨 CRITICAL: Custom error handling - DO NOT REMOVE
   ErrorWidget.builder = (FlutterErrorDetails details) {
@@ -28,11 +30,8 @@ void main() async {
     );
   };
   // 🚨 CRITICAL: Device orientation lock - DO NOT REMOVE
-  Future.wait([
-    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp])
-  ]).then((value) {
-    runApp(MyApp());
-  });
+  await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,9 +4,11 @@ import 'package:sizer/sizer.dart';
 
 import '../core/app_export.dart';
 import '../widgets/custom_error_widget.dart';
+import '../core/supabase_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await SupabaseService.init();
 
   // 🚨 CRITICAL: Custom error handling - DO NOT REMOVE
   ErrorWidget.builder = (FlutterErrorDetails details) {
@@ -15,11 +17,8 @@ void main() async {
     );
   };
   // 🚨 CRITICAL: Device orientation lock - DO NOT REMOVE
-  Future.wait([
-    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp])
-  ]).then((value) {
-    runApp(MyApp());
-  });
+  await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   fl_chart: ^0.65.0
   image_picker: ^1.0.4
   permission_handler: ^11.1.0
+  supabase_flutter: ^2.9.1
 
   universal_html: ^2.2.4
 dev_dependencies:


### PR DESCRIPTION
## Summary
- configure Supabase URL
- wire up Supabase auth and database client
- initialize Supabase during app startup

## Testing
- `dart format lib/core/env.dart lib/core/supabase_service.dart lib/main.dart lib/main-updated.dart lib/core/app_export.dart pubspec.yaml env.json` (fails: command not found)
- `flutter pub get` (fails: command not found)
- `dart analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689b6323cb68832eb5a31b432e255d76