### PR TITLE
feat: add supabase auth and registration

### DIFF
--- a/lib/core/supabase_service.dart
+++ b/lib/core/supabase_service.dart
@@ -15,6 +15,18 @@ class SupabaseService {
     return client.auth.signInWithPassword(email: email, password: password);
   }
 
+  static Future<AuthResponse> signUp(
+    String email,
+    String password, {
+    String? name,
+  }) {
+    return client.auth.signUp(
+      email: email,
+      password: password,
+      data: name != null ? {'name': name} : null,
+    );
+  }
+
   static Future<dynamic> fetchTable(String table) {
     return client.from(table).select();
   }

--- a/lib/presentation/register_screen/register_screen.dart
+++ b/lib/presentation/register_screen/register_screen.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:sizer/sizer.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../core/app_export.dart';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  bool _isLoading = false;
+  bool _agreed = false;
+
+  final Uri _privacyUrl =
+      Uri.parse('https://mutuus-app.de/pages/Datenschutz.html');
+  final Uri _termsUrl =
+      Uri.parse('https://mutuus-app.de/pages/AGB.html');
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _openUrl(Uri url) async {
+    if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Kann URL nicht öffnen: $url')),
+      );
+    }
+  }
+
+  Future<void> _handleRegister() async {
+    if (!(_formKey.currentState?.validate() ?? false) || !_agreed) {
+      if (!_agreed) {
+        _showError('Bitte stimme der Datenschutzerklärung und den AGB zu.');
+      }
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final res = await SupabaseService.signUp(
+        _emailController.text.trim(),
+        _passwordController.text,
+        name: _nameController.text.trim(),
+      );
+      if (res.user != null) {
+        HapticFeedback.lightImpact();
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content:
+                  Text('Registrierung erfolgreich. Bitte bestätige deine E-Mail.'),
+              duration: Duration(seconds: 4),
+            ),
+          );
+          Navigator.pop(context);
+        }
+      } else {
+        _showError(res.error?.message ?? 'Registrierung fehlgeschlagen.');
+      }
+    } on AuthException catch (e) {
+      _showError(e.message);
+    } catch (_) {
+      _showError('Registrierung fehlgeschlagen. Bitte versuche es erneut.');
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: AppTheme.lightTheme.colorScheme.error,
+        behavior: SnackBarBehavior.floating,
+        margin: EdgeInsets.all(4.w),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.lightTheme.colorScheme.surface,
+      appBar: AppBar(
+        title: const Text('Registrieren'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: EdgeInsets.symmetric(horizontal: 6.w, vertical: 2.h),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                  textInputAction: TextInputAction.next,
+                  validator: (v) =>
+                      v == null || v.isEmpty ? 'Name ist erforderlich' : null,
+                ),
+                SizedBox(height: 2.h),
+                TextFormField(
+                  controller: _emailController,
+                  decoration:
+                      const InputDecoration(labelText: 'E-Mail-Adresse'),
+                  keyboardType: TextInputType.emailAddress,
+                  textInputAction: TextInputAction.next,
+                  validator: (v) {
+                    if (v == null || v.isEmpty) {
+                      return 'E-Mail-Adresse ist erforderlich';
+                    }
+                    final emailRegex =
+                        RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+                    if (!emailRegex.hasMatch(v)) {
+                      return 'Bitte gültige E-Mail-Adresse eingeben';
+                    }
+                    return null;
+                  },
+                ),
+                SizedBox(height: 2.h),
+                TextFormField(
+                  controller: _passwordController,
+                  decoration: const InputDecoration(labelText: 'Passwort'),
+                  obscureText: true,
+                  textInputAction: TextInputAction.next,
+                  validator: (v) {
+                    if (v == null || v.isEmpty) {
+                      return 'Passwort ist erforderlich';
+                    }
+                    if (v.length < 6) {
+                      return 'Passwort muss mindestens 6 Zeichen enthalten';
+                    }
+                    return null;
+                  },
+                ),
+                SizedBox(height: 2.h),
+                TextFormField(
+                  controller: _confirmController,
+                  decoration:
+                      const InputDecoration(labelText: 'Passwort bestätigen'),
+                  obscureText: true,
+                  textInputAction: TextInputAction.done,
+                  validator: (v) {
+                    if (v == null || v.isEmpty) {
+                      return 'Bitte Passwort bestätigen';
+                    }
+                    if (v != _passwordController.text) {
+                      return 'Passwörter stimmen nicht überein';
+                    }
+                    return null;
+                  },
+                ),
+                SizedBox(height: 2.h),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Checkbox(
+                      value: _agreed,
+                      onChanged: (v) => setState(() => _agreed = v ?? false),
+                    ),
+                    Expanded(
+                      child: Wrap(
+                        children: [
+                          const Text('Ich stimme der '),
+                          GestureDetector(
+                            onTap: () => _openUrl(_privacyUrl),
+                            child: Text(
+                              'Datenschutzerklärung',
+                              style: TextStyle(
+                                color: AppTheme
+                                    .lightTheme.colorScheme.primary,
+                              ),
+                            ),
+                          ),
+                          const Text(' und den '),
+                          GestureDetector(
+                            onTap: () => _openUrl(_termsUrl),
+                            child: Text(
+                              'AGB',
+                              style: TextStyle(
+                                color: AppTheme
+                                    .lightTheme.colorScheme.primary,
+                              ),
+                            ),
+                          ),
+                          const Text(' zu.'),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 3.h),
+                SizedBox(
+                  height: 6.h,
+                  child: ElevatedButton(
+                    onPressed: _isLoading ? null : _handleRegister,
+                    child: _isLoading
+                        ? SizedBox(
+                            width: 5.w,
+                            height: 5.w,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                AppTheme.lightTheme.colorScheme.onPrimary,
+                              ),
+                            ),
+                          )
+                        : const Text('Registrieren'),
+                  ),
+                ),
+                SizedBox(height: 2.h),
+                TextButton(
+                  onPressed:
+                      _isLoading ? null : () => Navigator.pop(context),
+                  child: const Text('Schon ein Konto? Anmelden'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -3,6 +3,7 @@ import '../presentation/settings_and_account/settings_and_account.dart';
 import '../presentation/home_dashboard/home_dashboard.dart';
 import '../presentation/job_application/job_application.dart';
 import '../presentation/login_screen/login_screen.dart';
+import '../presentation/register_screen/register_screen.dart';
 import '../presentation/digital_wallet/digital_wallet.dart';
 import '../presentation/job_details/job_details.dart';
 
@@ -15,6 +16,7 @@ class AppRoutes {
   static const String login = '/login-screen';
   static const String digitalWallet = '/digital-wallet';
   static const String jobDetails = '/job-details';
+  static const String register = '/register-screen';
 
   static Map<String, WidgetBuilder> routes = {
     initial: (context) => const LoginScreen(),
@@ -24,6 +26,7 @@ class AppRoutes {
     login: (context) => const LoginScreen(),
     digitalWallet: (context) => const DigitalWallet(),
     jobDetails: (context) => const JobDetails(),
+    register: (context) => const RegisterScreen(),
     // TODO: Add your other routes here
   };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   image_picker: ^1.0.4
   permission_handler: ^11.1.0
   supabase_flutter: ^2.9.1
+  url_launcher: ^6.3.2
 
   universal_html: ^2.2.4
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add Supabase sign-up helper
- wire login to Supabase and add registration screen with consent links
- add url_launcher dependency and route for register screen

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b64d45b88832e9bc5bd72921d5940