### PR TITLE
feat: add karma system and notifications

### DIFF
--- a/lib/presentation/home_dashboard/home_dashboard.dart
+++ b/lib/presentation/home_dashboard/home_dashboard.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:sizer/sizer.dart';
 
 import '../../core/app_export.dart';
+import '../../services/karma_service.dart';
+import '../../services/notification_service.dart';
 import './widgets/empty_state_widget.dart';
 import './widgets/greeting_header_widget.dart';
 import './widgets/job_card_widget.dart';
@@ -126,11 +128,20 @@ class _HomeDashboardState extends State<HomeDashboard>
     },
   ];
 
+  Future<void> _loadUserData() async {
+    final karma = await KarmaService.getKarma();
+    setState(() {
+      _userData['karmaPoints'] = karma;
+      _userData['currentRank'] = KarmaService.rankForKarma(karma);
+    });
+  }
+
   @override
   void initState() {
     super.initState();
     _scrollController = ScrollController();
     _tabController = TabController(length: 5, vsync: this);
+    _loadUserData();
   }
 
   @override
@@ -165,13 +176,23 @@ class _HomeDashboardState extends State<HomeDashboard>
   }
 
   void _createNewJob() {
-    // Navigate to job creation flow
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Job erstellen wird geöffnet...'),
-        duration: Duration(seconds: 2),
-      ),
-    );
+    final newJob = {
+      'id': DateTime.now().millisecondsSinceEpoch,
+      'title': 'Nachbarschaftshilfe',
+      'description': 'Hilf einem Nachbarn beim Einkauf.',
+      'category': 'Hilfe',
+      'categoryIcon': 'favorite',
+      'paymentType': 'karma',
+      'karmaPoints': 30,
+      'distance': 0.0,
+      'deadline': 'Heute',
+      'requiredRank': 'Starter',
+      'isPremium': false,
+    };
+    setState(() {
+      _newJobs.add(newJob);
+    });
+    NotificationService.show('Neuer Karma-Job erstellt: ${newJob['title']}');
   }
 
   Widget _buildJobSection({

--- a/lib/presentation/job_application/job_application.dart
+++ b/lib/presentation/job_application/job_application.dart
@@ -5,6 +5,8 @@ import 'package:image_picker/image_picker.dart';
 import 'package:sizer/sizer.dart';
 
 import '../../core/app_export.dart';
+import '../../services/karma_service.dart';
+import '../../services/notification_service.dart';
 import './widgets/application_terms_section.dart';
 import './widgets/availability_section.dart';
 import './widgets/job_summary_card.dart';
@@ -213,6 +215,16 @@ class _JobApplicationState extends State<JobApplication>
 
       // Show success animation
       await _showSuccessAnimation();
+
+      // Award karma for karma-based jobs
+      if (jobData['paymentType'] == 'karma') {
+        final points = jobData['karmaPoints'] as int? ?? 0;
+        final updated = await KarmaService.addKarma(points);
+        final rank = KarmaService.rankForKarma(updated);
+        NotificationService.show('Karma-Job angenommen: +$points Karma (Rang: $rank)');
+      } else {
+        NotificationService.show('Bewerbung gesendet');
+      }
 
       // Navigate to applications screen
       if (mounted) {

--- a/lib/services/karma_service.dart
+++ b/lib/services/karma_service.dart
@@ -1,0 +1,33 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Manages Karma point storage and rank calculations.
+class KarmaService {
+  KarmaService._();
+
+  static const _karmaKey = 'karma_points';
+
+  /// Returns the current Karma points stored on the device.
+  static Future<int> getKarma() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_karmaKey) ?? 0;
+  }
+
+  /// Adds [points] to the stored Karma and returns the updated total.
+  static Future<int> addKarma(int points) async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = prefs.getInt(_karmaKey) ?? 0;
+    final updated = current + points;
+    await prefs.setInt(_karmaKey, updated);
+    return updated;
+  }
+
+  /// Determines the rank name for a given Karma amount.
+  static String rankForKarma(int karma) {
+    if (karma >= 1000) return 'Vorbild';
+    if (karma >= 500) return 'Vertrauensperson';
+    if (karma >= 250) return 'Erfahren';
+    if (karma >= 100) return 'Community';
+    return 'Starter';
+  }
+}
+

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,11 @@
+import 'package:fluttertoast/fluttertoast.dart';
+
+/// Simple wrapper around [Fluttertoast] to display user notifications.
+class NotificationService {
+  NotificationService._();
+
+  static void show(String message) {
+    Fluttertoast.showToast(msg: message);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add KarmaService to manage points and ranks
- implement simple NotificationService using Fluttertoast
- award karma and show notifications when applying to karma jobs
- load karma/rank dynamically and notify when creating karma jobs

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `snap install flutter --classic` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b65cf9b88832eb7cd81587ede8b1a