### PR TITLE
feat: add basic navigation screens

### DIFF
--- a/lib/presentation/community_screen/community_screen.dart
+++ b/lib/presentation/community_screen/community_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class CommunityScreen extends StatelessWidget {
+  const CommunityScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(
+        title: Text('Community'),
+      ),
+      body: Center(
+        child: Text('Community-Funktionen folgen'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/home_dashboard/home_dashboard.dart
+++ b/lib/presentation/home_dashboard/home_dashboard.dart
@@ -207,16 +207,16 @@ class _HomeDashboardState extends State<HomeDashboard>
                 Navigator.pushNamed(context, '/home-dashboard');
               }),
               _buildMenuItem('Jobs', 'search', () {
-                // TODO: Navigate to Jobs screen
+                Navigator.pushNamed(context, AppRoutes.jobs);
               }),
               _buildMenuItem('Profil', 'person', () {
-                // TODO: Navigate to Profile screen
+                Navigator.pushNamed(context, AppRoutes.profile);
               }),
               _buildMenuItem('Wallet', 'account_balance_wallet', () {
                 Navigator.pushNamed(context, '/digital-wallet');
               }),
               _buildMenuItem('Community', 'group', () {
-                // TODO: Navigate to Community screen
+                Navigator.pushNamed(context, AppRoutes.community);
               }),
               _buildMenuItem('Einstellungen', 'settings', () {
                 Navigator.pushNamed(context, '/settings-and-account');
@@ -471,14 +471,14 @@ class _HomeDashboardState extends State<HomeDashboard>
                 // Already on Home
                 break;
               case 1:
-                // Navigate to Jobs
+                Navigator.pushNamed(context, AppRoutes.jobs);
                 break;
               case 2:
                 // Open Menu
                 _showMainMenu();
                 break;
               case 3:
-                // Navigate to Profile
+                Navigator.pushNamed(context, AppRoutes.profile);
                 break;
               case 4:
                 // Navigate to Settings

--- a/lib/presentation/jobs_screen/jobs_screen.dart
+++ b/lib/presentation/jobs_screen/jobs_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../core/app_export.dart';
+
+class JobsScreen extends StatelessWidget {
+  const JobsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final jobs = [
+      {'title': 'Möbel aufbauen', 'description': 'IKEA Kleiderschrank, ca. 2h'},
+      {'title': 'Einkaufen', 'description': 'Wöchentlicher Einkauf übernehmen'},
+      {'title': 'Hund ausführen', 'description': 'Golden Retriever Bruno, 1h täglich'},
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Jobs'),
+      ),
+      body: ListView.separated(
+        itemCount: jobs.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final job = jobs[index];
+          return ListTile(
+            title: Text(job['title']!),
+            subtitle: Text(job['description']!),
+            onTap: () {
+              Navigator.pushNamed(context, AppRoutes.jobDetails);
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/profile_screen/profile_screen.dart
+++ b/lib/presentation/profile_screen/profile_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatefulWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  State<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Profil'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (value) => value == null || value.isEmpty
+                    ? 'Bitte Name eingeben'
+                    : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'E-Mail'),
+                validator: (value) => value == null || value.isEmpty
+                    ? 'Bitte E-Mail eingeben'
+                    : null,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Profil gespeichert')),
+                    );
+                  }
+                },
+                child: const Text('Speichern'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -6,6 +6,9 @@ import '../presentation/login_screen/login_screen.dart';
 import '../presentation/register_screen/register_screen.dart';
 import '../presentation/digital_wallet/digital_wallet.dart';
 import '../presentation/job_details/job_details.dart';
+import '../presentation/jobs_screen/jobs_screen.dart';
+import '../presentation/profile_screen/profile_screen.dart';
+import '../presentation/community_screen/community_screen.dart';
 
 class AppRoutes {
   // TODO: Add your routes here
@@ -17,6 +20,9 @@ class AppRoutes {
   static const String digitalWallet = '/digital-wallet';
   static const String jobDetails = '/job-details';
   static const String register = '/register-screen';
+  static const String jobs = '/jobs';
+  static const String profile = '/profile';
+  static const String community = '/community';
 
   static Map<String, WidgetBuilder> routes = {
     initial: (context) => const LoginScreen(),
@@ -27,6 +33,9 @@ class AppRoutes {
     digitalWallet: (context) => const DigitalWallet(),
     jobDetails: (context) => const JobDetails(),
     register: (context) => const RegisterScreen(),
+    jobs: (context) => const JobsScreen(),
+    profile: (context) => const ProfileScreen(),
+    community: (context) => const CommunityScreen(),
     // TODO: Add your other routes here
   };
 }


### PR DESCRIPTION
## Summary
- add placeholder screens for jobs, profile, and community
- wire up navigation routes and menu actions
- enable job and profile access from bottom navigation

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6c1c35ec832e9744783b840608e6